### PR TITLE
Added Queue, test script  and more

### DIFF
--- a/hive-watcher/hive-watcher.py
+++ b/hive-watcher/hive-watcher.py
@@ -29,7 +29,7 @@ def get_allowed_accounts(acc_name) -> bool:
         and only react to these accounts """
 
     if USE_TEST_NODE:
-        return ['learn-to-code','hive-hydra','hivehydra','flyingboy']
+        return ['learn-to-code','hive-hydra','hivehydra','flyingboy','blocktvnews']
 
     hiveaccount = Account(acc_name, blockchain_instance=hive, lazy=True)
     try:

--- a/hive-writer/hive-writer-test.py
+++ b/hive-writer/hive-writer-test.py
@@ -3,8 +3,12 @@
 
 # Changed the range number for how many times you want to hit the server
 import socket
+import time
 
-for n in range(10):
+start = time.perf_counter()
+
+for n in range(1000):
+
     # Create a client socket
     clientSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # Connect to the server
@@ -18,3 +22,5 @@ for n in range(10):
     print(dataFromServer.decode())
 
     clientSocket.close()
+
+print('Time taken: ' + str(time.perf_counter() - start) )

--- a/hive-writer/hive-writer-test.py
+++ b/hive-writer/hive-writer-test.py
@@ -1,0 +1,28 @@
+
+#----- A simple TCP client program in Python using send() function -----
+
+import socket
+
+
+
+
+
+
+
+
+
+for n in range(10):
+    # Create a client socket
+
+    clientSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # Connect to the server
+    clientSocket.connect(("127.0.0.1",9999))
+    # Send data to server
+    data = f"https://www.brianoflondon.me/{n}/podcast2/brians-forest-talks-exp.xml"
+    clientSocket.send(data.encode())
+    # Receive data from server
+    dataFromServer = clientSocket.recv(1024)
+    # Print to the console
+    print(dataFromServer.decode())
+
+    clientSocket.close()

--- a/hive-writer/hive-writer-test.py
+++ b/hive-writer/hive-writer-test.py
@@ -1,19 +1,11 @@
 
 #----- A simple TCP client program in Python using send() function -----
 
+# Changed the range number for how many times you want to hit the server
 import socket
-
-
-
-
-
-
-
-
 
 for n in range(10):
     # Create a client socket
-
     clientSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # Connect to the server
     clientSocket.connect(("127.0.0.1",9999))

--- a/hive-writer/hive-writer.py
+++ b/hive-writer/hive-writer.py
@@ -91,7 +91,7 @@ def send_notification_worker():
         args = items[1:]
         start = time.perf_counter()
         trx_id, success = func(*args)
-        # Limit the rate to 1 post ever 2 seconds, this will mostly avoid
+        # Limit the rate to 1 post every 2 seconds, this will mostly avoid
         # multiple updates in a single Hive block.
         duration = time.perf_counter() - start
         if duration < 2.0:

--- a/hive-writer/hive-writer.py
+++ b/hive-writer/hive-writer.py
@@ -1,13 +1,14 @@
 import logging
-import socket
 from beem import Hive
 import os
 import threading
+import queue
 import socketserver
+import time
 
 # Testnet instead of main Hive
 # BOL: Switching off TestNet, we should test on Hive for now.
-USE_TEST_NODE = False
+USE_TEST_NODE = os.getenv("USE_TEST_NODE", 'False').lower() in ('true', '1', 't')
 TEST_NODE = ['http://testnet.openhive.network:8091']
 
 logging.basicConfig(level=logging.INFO,
@@ -26,7 +27,7 @@ class MyTCPHandler(socketserver.BaseRequestHandler):
         # self.request is the TCP socket connected to the client
         self.data = self.request.recv(1024).strip()
         url = self.data.decode("utf-8")
-        print("{}: {}".format(self.client_address[0], url))
+        logging.info("Received from {}: {}".format(self.client_address[0], url))
         url_in(url)
         self.request.sendall("OK".encode("utf-8"))
 
@@ -34,9 +35,10 @@ class MyTCPHandler(socketserver.BaseRequestHandler):
 def url_in(url):
     """ Send a URL and I'll post it to Hive """
     custom_json = {'url': url}
-    trx_id, success = send_notification(custom_json=custom_json)
-    custom_json['trx_id'] = trx_id
-    custom_json['success'] = success
+    hive_q.put( (send_notification, custom_json ))
+    # trx_id, success = send_notification(custom_json=custom_json)
+    # custom_json['trx_id'] = trx_id
+    # custom_json['success'] = success
     #emit('response', {'data': custom_json})
 
 
@@ -76,9 +78,33 @@ def send_notification(custom_json, server_account='', wif=''):
         trx_id = error_message
         return trx_id, False
 
+#Adding a Queue system to the Hive send_notification section
+
+hive_q = queue.Queue()
+
+
+def send_notification_worker():
+    """ Opens and watches a queue and sends notifications to Hive one by one """
+    while True:
+        items = hive_q.get()
+        func = items[0]
+        args = items[1:]
+        start = time.perf_counter()
+        trx_id, success = func(*args)
+        # Limit the rate to 1 post ever 2 seconds, this will mostly avoid
+        # multiple updates in a single Hive block.
+        duration = time.perf_counter() - start
+        if duration < 2.0:
+            time.sleep(2.0-duration)
+        hive_q.task_done()
+        logging.info(f'Task time: {duration:0.2f} - Queue size: ' + str(hive_q.qsize()))
+        logging.info(f'Finished a task: {trx_id} - {success}')
+
+threading.Thread(target=send_notification_worker, daemon=True).start()
+
 
 if __name__ == "__main__":
-    HOST, PORT = "localhost", 5001
+    HOST, PORT = "localhost", 9999
 
     # Create the server, binding to localhost on port 9999
     server = socketserver.TCPServer((HOST, PORT), MyTCPHandler)


### PR DESCRIPTION
I've added a queue system to the hive-writer which will take in new requests and send them out every 2s. It actually takes about 1.1s to post to Hive but I'm padding that out to 2s. The block time is 3s which means we will generally avoid having more than 2 updates per block.

I did some really heavy tests on this using the little test script posting in 1000 updates at a time and it chugged through them without trouble on the Test net. I mistakenly posted 374 times to the main net from an account with only 10 HP and that worked until it ran out of resource credits. I'm giving hivehydra 100 HP (10x) that right now.

I still think you (Dave) should test directly on main net Hive and your account probably has the power to do around 3000 updates in one go but i don't think you should, if you're ok with testing in blocks of 50 or so that would probably prove that this works.