### PR TITLE
Optional dual-write to gossip-writer alongside hive-writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ iroh-gossip swarm in addition to the Hive blockchain, via
 - `GOSSIP_WRITER_ZMQ` (default `127.0.0.1:9998`) — `host:port` of the
   gossip-writer's ZMQ socket.
 
-The gossip send is fire-and-forget (50ms timeout, non-blocking): if the
-gossip-writer is slow, down, or absent, Hive writes are completely
-unaffected. To disable, set `GOSSIP_WRITER_ENABLED=false` (or remove the
-gossip-writer service) and restart — no other state changes.
+The gossip send is fire-and-forget and non-blocking, and replies from the
+gossip-writer are drained and ignored: if the gossip-writer is slow, down,
+or absent, Hive writes are completely unaffected. To disable, set
+`GOSSIP_WRITER_ENABLED=false` (or remove the gossip-writer service) and
+restart — no other state changes.

--- a/README.md
+++ b/README.md
@@ -90,3 +90,22 @@ example of the format for publisher token records.
 ## The Podping Network Idea
 
 ![Framework Overview 1](framework1.png)
+
+<br>
+
+## Gossip dual-write (experimental)
+
+podping.cloud can optionally broadcast every podping to a decentralized
+iroh-gossip swarm in addition to the Hive blockchain, via
+[podping-gossipwriter](https://github.com/Podcastindex-org/podping-gossipwriter).
+
+- `GOSSIP_WRITER_ENABLED` (default `false`) — when `true`, the front-end
+  opens a second ZMQ PAIR socket and sends each podping to the
+  gossip-writer as well as the hive-writer.
+- `GOSSIP_WRITER_ZMQ` (default `127.0.0.1:9998`) — `host:port` of the
+  gossip-writer's ZMQ socket.
+
+The gossip send is fire-and-forget (50ms timeout, non-blocking): if the
+gossip-writer is slow, down, or absent, Hive writes are completely
+unaffected. To disable, set `GOSSIP_WRITER_ENABLED=false` (or remove the
+gossip-writer service) and restart — no other state changes.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
       - /data:/data
     environment:
       ZMQ_SOCKET_ADDR: "192.168.69.69:9999"
+      GOSSIP_WRITER_ENABLED: "true"
+      GOSSIP_WRITER_ZMQ: "192.168.69.70:9998"
     networks:
       podping:
         ipv4_address: 192.168.69.68
@@ -33,6 +35,29 @@ services:
     networks:
       podping:
         ipv4_address: 192.168.69.69
+    logging:
+      driver: "syslog"
+      options:
+        tag: "{{.ImageName}}/{{.Name}}/{{.ID}}"
+
+  gossip-writer:
+    image: podcastindexorg/podping-gossipwriter:0.7.0
+    init: true
+    restart: unless-stopped
+    stop_grace_period: 30s
+    user: "1000:1000"
+    environment:
+      ZMQ_BIND_ADDR: "tcp://0.0.0.0:9998"
+      IROH_SECRET_FILE: "/data/gossip/iroh.key"
+      IROH_NODE_KEY_FILE: "/data/gossip/iroh_node.key"
+      ARCHIVE_ENABLED: "true"
+      ARCHIVE_PATH: "/data/gossip/archive.db"
+      TRUSTED_MONITORS_FILE: "/data/gossip/trusted_monitors.txt"
+    volumes:
+      - /data/gossip:/data/gossip
+    networks:
+      podping:
+        ipv4_address: 192.168.69.70
     logging:
       driver: "syslog"
       options:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   podping-cloud:
-    image: podcastindexorg/podcasting20-podping.cloud:2.1.0
+    image: podcastindexorg/podcasting20-podping.cloud:3.0.0
     init: true
     restart: unless-stopped
     stop_grace_period: 1m

--- a/docs/gossip-canary-runbook.md
+++ b/docs/gossip-canary-runbook.md
@@ -1,0 +1,49 @@
+# Gossip dual-write canary runbook
+
+Target: ONE of the 5 production podping.cloud servers.
+
+## Prepare
+1. `docker pull podcastindexorg/podping-gossipwriter:0.7.0` and the 3.0.0
+   front-end image — confirm both pull before touching anything.
+2. `sudo mkdir -p /data/gossip && sudo chown 1000:1000 /data/gossip`
+3. Do NOT touch `/opt/podping.cloud/hivewriter.env`.
+4. Back up the current compose file:
+   `cp docker-compose.yaml docker-compose.yaml.pre-gossip`
+
+## Deploy
+5. Replace the compose file with the gossip-dual-write version
+   (front-end image 3.0.0, `GOSSIP_WRITER_ENABLED=true`, gossip-writer service).
+6. `docker compose pull && docker compose up -d`
+7. `docker compose logs -f podping-cloud | head -50` — expect
+   "Gossip PAIR socket: [...] connected." alongside the normal startup.
+8. `docker compose logs gossip-writer | head -50` — note the printed
+   signing pubkey; you'll trust it in step 10.
+
+## Verify (all 5 must pass)
+9.  HIVE UNHARMED: existing Hive monitoring shows podpings from this
+    server continuing at the normal rate. THE MUST-NOT-BREAK INVARIANT.
+10. GOSSIP LIVE: on a separate machine, run gossip-listener and
+    gossip-monitor (from podping.alpha), add the canary's pubkey (step 8)
+    to trusted_publishers.txt, and observe verified notifications arriving.
+11. ARCHIVE FILLING: on the server:
+    `sqlite3 /data/gossip/archive.db 'select count(*) from messages;'`
+    twice, a few minutes apart — count grows with traffic.
+12. FAILURE DRILL (during real traffic):
+    `docker compose stop gossip-writer` → front-end keeps serving HTTP,
+    Hive podpings keep flowing (front-end logs show only
+    "Gossip write failed" lines) →
+    `docker compose start gossip-writer` → listener sees notifications
+    resume within ~2 minutes.
+13. SOAK 48h: watch `docker stats gossip-writer` for memory growth
+    (iroh-gossip churn leak) and syslog for panic/abort from iroh-quinn.
+
+## Rollback (any time)
+- Soft: set `GOSSIP_WRITER_ENABLED: "false"` in compose,
+  `docker compose up -d podping-cloud`.
+- Full: `cp docker-compose.yaml.pre-gossip docker-compose.yaml &&
+  docker compose up -d --remove-orphans`.
+- The Hive path is untouched by design; rollback risk is near zero.
+
+## Done
+All 5 checks pass → merge the gossip-dual-write PR. Rollout to the other
+4 servers is a separate follow-on effort.

--- a/docs/gossip-canary-runbook.md
+++ b/docs/gossip-canary-runbook.md
@@ -34,6 +34,10 @@ Target: ONE of the 5 production podping.cloud servers.
     "Gossip write failed" lines) →
     `docker compose start gossip-writer` → listener sees notifications
     resume within ~2 minutes.
+    Also drill the Hive retry path: `docker compose stop hive-writer` for
+    ~5 minutes during traffic, then start it again -- every ping received
+    during the outage must eventually land on Hive (the front-end re-sends
+    unacked pings after 180s; gossip acks do not remove them from the queue).
 13. SOAK 48h: watch `docker stats gossip-writer` for memory growth
     (iroh-gossip churn leak) and syslog for panic/abort from iroh-quinn.
 

--- a/podping/Cargo.toml
+++ b/podping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podping"
-version = "2.1.0"
+version = "3.0.0"
 authors = ["Dave Jones"]
 edition = "2021"
 build = "build.rs"

--- a/podping/src/main.rs
+++ b/podping/src/main.rs
@@ -29,6 +29,8 @@ const ZMQ_SOCKET_ADDR: &str = "127.0.0.1:9999";
 const ZMQ_RECV_TIMEOUT: i32 = 10;
 //const LOOP_TIMER_SECONDS: u64 = 1;
 const LOOP_TIMER_MILLISECONDS: u64 = 500;
+const GOSSIP_ZMQ_ADDR: &str = "127.0.0.1:9998";
+const GOSSIP_ZMQ_SEND_TIMEOUT: i32 = 50; // 50ms, fire-and-forget
 mod handler;
 mod router;
 type Response = hyper::Response<hyper::Body>;
@@ -122,20 +124,57 @@ async fn main() {
             println!(" - Trying localhost default: [{}].", zmq_address);
         }
 
-        //Set up and connect the socket
+        //Create a ZMQ socket context
         let context = zmq::Context::new();
-        let mut requester = context.socket(zmq::PAIR).unwrap();
-        if requester.set_rcvtimeo(ZMQ_RECV_TIMEOUT).is_err() {
+
+        //Create the socket for the hive-writer
+        let mut zmq_hive = context.socket(zmq::PAIR).unwrap();
+        if zmq_hive.set_rcvtimeo(ZMQ_RECV_TIMEOUT).is_err() {
             eprintln!("  Failed to set zmq receive timeout.");
         }
-        if requester.set_linger(0).is_err() {
+        if zmq_hive.set_sndtimeo(1000).is_err() {
+            eprintln!("  Failed to set zmq send timeout.");
+        }
+        if zmq_hive.set_linger(0).is_err() {
             eprintln!("  Failed to set zmq to zero linger.");
         }
-        if requester.connect(&zmq_address).is_err() {
+        if zmq_hive.connect(&zmq_address).is_err() {
             eprintln!("  Failed to connect to the podping writer socket.");
         }
-
         println!("ZMQ socket: [{}] connected.", zmq_address);
+
+        //Create the socket for the gossip-writer (if enabled)
+        let zmq_gossip: Option<zmq::Socket> = {
+            let enabled = std::env::var("GOSSIP_WRITER_ENABLED")
+                .unwrap_or_else(|_| "false".to_string());
+            if enabled.eq_ignore_ascii_case("true") || enabled == "1" {
+                let gossip_addr = std::env::var("GOSSIP_WRITER_ZMQ")
+                    .unwrap_or_else(|_| GOSSIP_ZMQ_ADDR.to_string());
+                let gossip_addr = format!("tcp://{}", gossip_addr);
+                println!("Gossip writer enabled, connecting PAIR socket to [{}]...", gossip_addr);
+                let gsock = context.socket(zmq::PAIR).unwrap();
+                if gsock.set_sndtimeo(GOSSIP_ZMQ_SEND_TIMEOUT).is_err() {
+                    eprintln!("  Failed to set gossip zmq send timeout.");
+                }
+                if gsock.set_rcvtimeo(0).is_err() {
+                    eprintln!("  Failed to set gossip zmq receive timeout.");
+                }
+                if gsock.set_linger(0).is_err() {
+                    eprintln!("  Failed to set gossip zmq to zero linger.");
+                }
+                if gsock.set_sndhwm(10000).is_err() {
+                    eprintln!("  Failed to set gossip zmq send HWM.");
+                }
+                if gsock.connect(&gossip_addr).is_err() {
+                    eprintln!("  Failed to connect gossip PAIR socket.");
+                }
+                println!("Gossip PAIR socket: [{}] connected.", gossip_addr);
+                Some(gsock)
+            } else {
+                println!("Gossip writer disabled (set GOSSIP_WRITER_ENABLED=true to enable).");
+                None
+            }
+        };
 
         //Spawn a queue checker threader.  Every X seconds, get all the pings from the Queue and attempt to write them
         //to the socket that the Hive-writer should be listening on
@@ -149,8 +188,12 @@ async fn main() {
                 Err(_) => eprintln!("SystemTime before UNIX EPOCH!"),
             }
 
-            //We always want to try and receive any waiting socket messages before moving on to sending
-            receive_messages(&requester);
+            //We always want to try and receive any waiting socket messages before moving on to
+            // sending. Both sockets should be given a chance
+            receive_messages(&zmq_hive);
+            if let Some(ref gsock) = zmq_gossip {
+                while receive_messages(gsock) {}
+            }
 
             //Get the most recent X number of pings from the queue database
             let pinglist = dbif::get_pings_from_queue(false);
@@ -213,10 +256,19 @@ async fn main() {
                         let podping_write_reader = Reader::from(write_message_buffer.as_slice());
                         plexo_message.set_payload(podping_write_reader);
 
-                        //Attempt to send the message over the ZMQ socket
+                        //Write the capnp structured message to the send buffer
                         let mut send_buffer = Vec::new();
                         capnp::serialize::write_message(&mut send_buffer, &message).unwrap();
-                        match requester.send(send_buffer, 0) {
+
+                        //Send the message to the gossip-writer (if enabled)
+                        if let Some(ref gsock) = zmq_gossip {
+                            if let Err(e) = gsock.send(send_buffer.as_slice(), zmq::DONTWAIT) {
+                                eprintln!("      Gossip write failed: [{}]", e);
+                            }
+                        }
+
+                        //Send the message to the hive-writer
+                        match zmq_hive.send(send_buffer, 0) {
                             Ok(_) => {
                                 // println!("      IRI sent.");
                                 //If the write was successful, mark this ping as "in flight"
@@ -241,17 +293,20 @@ async fn main() {
                             },
                             Err(e) => {
                                 eprintln!("      {}", e);
-                                if requester.disconnect(&zmq_address).is_err() {
+                                if zmq_hive.disconnect(&zmq_address).is_err() {
                                     eprintln!("      Failed to disconnect zmq socket.");
                                 }
-                                requester = context.socket(zmq::PAIR).unwrap();
-                                if requester.set_rcvtimeo(ZMQ_RECV_TIMEOUT).is_err() {
+                                zmq_hive = context.socket(zmq::PAIR).unwrap();
+                                if zmq_hive.set_rcvtimeo(ZMQ_RECV_TIMEOUT).is_err() {
                                     eprintln!("      Failed to set zmq receive timeout.");
                                 }
-                                if requester.set_linger(0).is_err() {
+                                if zmq_hive.set_sndtimeo(1000).is_err() {
+                                    eprintln!("      Failed to set zmq send timeout.");
+                                }
+                                if zmq_hive.set_linger(0).is_err() {
                                     eprintln!("      Failed to set zmq to zero linger.");
                                 }
-                                if requester.connect(&zmq_address).is_err() {
+                                if zmq_hive.connect(&zmq_address).is_err() {
                                     eprintln!("      Failed to re-connect to the hive-writer socket.");
                                 }
                                 break;
@@ -260,7 +315,10 @@ async fn main() {
 
                         //Again, try to receive any messages waiting on the socket so that we effectively
                         //interleave the receives and sends to speed things up and not have one "block" the other
-                        receive_messages(&requester);
+                        receive_messages(&zmq_hive);
+                        if let Some(ref gsock) = zmq_gossip {
+                            while receive_messages(gsock) {}
+                        }
                         sent += 1;
                     }
                 },

--- a/podping/src/main.rs
+++ b/podping/src/main.rs
@@ -192,7 +192,7 @@ async fn main() {
             // sending. Both sockets should be given a chance
             receive_messages(&zmq_hive);
             if let Some(ref gsock) = zmq_gossip {
-                while receive_messages(gsock) {}
+                drain_gossip_messages(gsock);
             }
 
             //Get the most recent X number of pings from the queue database
@@ -317,7 +317,7 @@ async fn main() {
                         //interleave the receives and sends to speed things up and not have one "block" the other
                         receive_messages(&zmq_hive);
                         if let Some(ref gsock) = zmq_gossip {
-                            while receive_messages(gsock) {}
+                            drain_gossip_messages(gsock);
                         }
                         sent += 1;
                     }
@@ -498,6 +498,13 @@ fn receive_messages(requester: &zmq::Socket) -> bool {
             false
         }
     }
+}
+
+//Drain and discard any replies from the gossip-writer.  Gossip acks must never
+//affect the queue - only the hive-writer's replies are authoritative.
+fn drain_gossip_messages(gsock: &zmq::Socket) {
+    let mut response = Message::new();
+    while gsock.recv(&mut response, 0).is_ok() { }
 }
 
 async fn route(


### PR DESCRIPTION
Adds an optional second writer path: when GOSSIP_WRITER_ENABLED=true, the front-end sends each podping to a [podping-gossipwriter](https://github.com/Podcastindex-org/podping-gossipwriter) sidecar over a fire-and-forget ZMQ PAIR socket, in addition to the normal hive-writer send.

Default off — zero behavior change unless enabled, with one disclosed exception below. The gossip send is non-blocking (DONTWAIT, 10k HWM), and replies from the gossip-writer are drained and ignored — only hive-writer acks can remove pings from the retry queue, so a slow, dead, or misbehaving gossip-writer can never block or corrupt the Hive path.

Disclosed behavior change (applies even when disabled): the hive-writer socket gains a 1s send timeout (previously it could block indefinitely). If the hive-writer stalls with a full pipe, the front-end now errors after 1s and takes the existing reconnect path instead of freezing the queue thread; unacked pings are re-sent by the existing 180s inflight backstop. This has run for months on the podping.alpha R&D fork. Also included: requester → zmq_hive rename for two-socket readability.

Compose gains a gossip-writer sidecar service and bumps the front-end to 3.0.0; README documents the new env vars and failure semantics; docs/gossip-canary-runbook.md is the staged rollout plan (canary on one production server, including hive-outage and gossip-outage failure drills, before merging).