### PR TITLE
Build and publish the front-end image via GitHub Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+podping/target
+.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y capnproto libzmq3-dev libssl-dev pkg-config
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: podping
+      - name: Check
+        working-directory: podping
+        run: cargo check --locked
+      - name: Clippy
+        working-directory: podping
+        run: cargo clippy --locked
+      - name: Build
+        working-directory: podping
+        run: cargo build --locked
+      - name: Docker build
+        run: docker build -f docker/Dockerfile -t podping-cloud-ci .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: |
+            podcastindexorg/podcasting20-podping.cloud:${{ steps.version.outputs.version }}
+            podcastindexorg/podcasting20-podping.cloud:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,12 +5,10 @@ USER root
 
 RUN apt-get update && apt-get install -y apt-utils sqlite3 openssl capnproto libzmq3-dev && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /opt
-ARG GIT_REPO=https://github.com/Podcastindex-org/podping.cloud.git
-ARG GIT_BRANCH=main
-RUN git clone --depth 1 -b ${GIT_BRANCH} ${GIT_REPO}
+WORKDIR /opt/podping.cloud
+COPY podping/ podping/
 WORKDIR /opt/podping.cloud/podping
-RUN cargo build --release
+RUN cargo build --release --locked
 RUN cp target/release/podping .
 
 

--- a/docker/multi-arch-builder.sh
+++ b/docker/multi-arch-builder.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-docker buildx rm builder
-docker buildx create --name builder --driver docker-container --use
-docker buildx inspect --bootstrap
-sudo docker buildx build --platform linux/amd64 --tag podcastindexorg/podcasting20-podping.cloud:2.1.0 --tag podcastindexorg/podcasting20-podping.cloud:latest --no-cache --output "type=registry" .

--- a/podping/Cargo.lock
+++ b/podping/Cargo.lock
@@ -804,7 +804,7 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "podping"
-version = "0.2.2"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",


### PR DESCRIPTION
Converts the manual docker/multi-arch-builder.sh process to GitHub Actions, mirroring podping-gossipwriter:

- Dockerfile builds from the checkout instead of git-cloning main inside the build — releases now build exactly the tagged commit. Adds --locked and a root .dockerignore.
- ci.yml: cargo check/clippy/build + a Docker smoke build on pushes and PRs (no secrets needed, so fork PRs get full verification).
- release.yml: tag vX.Y.Z → publishes podcastindexorg/podcasting20-podping.cloud:X.Y.Z and :latest (linux/amd64).
- Cargo.lock sync: the lock still recorded podping 0.2.2 from before the 3.0.0 bump; --locked builds would fail without it. Only the workspace-member version entry changed.
- Removes multi-arch-builder.sh.