### PR TITLE
fix runtime glibc mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,7 @@ jobs:
         run: cargo build --locked
       - name: Docker build
         run: docker build -f docker/Dockerfile -t podping-cloud-ci .
+      - name: Verify binary links in runtime image
+        run: |
+          docker run --rm --entrypoint /bin/sh podping-cloud-ci -c "ldd /opt/podping/podping" | tee ldd.out
+          ! grep "not found" ldd.out

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ##: Build stage
-FROM rust:latest AS builder
+FROM rust:1-trixie AS builder
 
 USER root
 
@@ -13,7 +13,10 @@ RUN cp target/release/podping .
 
 
 ##: Bundle stage
-FROM debian:bookworm-slim AS runner
+# Must be the same Debian release as the builder image: the binary links
+# against the builder's glibc, and a newer builder glibc than the runner's
+# fails at startup with "version `GLIBC_X.YZ' not found".
+FROM debian:trixie-slim AS runner
 
 USER root
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   podping-cloud:
-    image: podcastindexorg/podcasting20-podping.cloud:3.0.0
+    image: podcastindexorg/podcasting20-podping.cloud:3.0.1
     init: true
     restart: unless-stopped
     stop_grace_period: 1m

--- a/podping/Cargo.lock
+++ b/podping/Cargo.lock
@@ -804,7 +804,7 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "podping"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",

--- a/podping/Cargo.toml
+++ b/podping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podping"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Dave Jones"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
rust:latest silently moved from bookworm to trixie (glibc 2.41), so binaries required GLIBC_2.38+ that the bookworm-slim runner (glibc 2.36) lacks — the 3.0.0 image crash-loops at startup. Pin both stages to the same named release and add a CI ldd check so linker skew fails the PR instead of the deploy. Bump to 3.0.1.