### PR TITLE
gossip-writer env file

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -46,6 +46,12 @@ services:
     restart: unless-stopped
     stop_grace_period: 30s
     user: "1000:1000"
+    # Host-specific settings (e.g. NODE_FRIENDLY_NAME=podping-australia).
+    # Lives outside the deploy dir so it survives image/compose updates;
+    # keys in `environment:` below take precedence over this file.
+    env_file:
+      - path: /opt/podping.cloud/gossipwriter.env
+        required: false
     environment:
       ZMQ_BIND_ADDR: "tcp://0.0.0.0:9998"
       IROH_SECRET_FILE: "/data/gossip/iroh.key"


### PR DESCRIPTION
Add gossip-writer env file for persistence of vars across deploys.

Optional env file (same pattern as hivewriter.env) so hosts can set NODE_FRIENDLY_NAME etc. without editing the shared compose file.